### PR TITLE
ci: macos-13 runners deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15]
     steps:
 # Now handled by Homebrew/actions/setup-homebrew
 # See: https://github.com/Homebrew/actions/blob/master/setup-homebrew/main.sh#L207-L242


### PR DESCRIPTION
GitHub Actions error was:

> The macOS-13 based runner images are being deprecated, consider switching to
> macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more
> details see https://github.com/actions/runner-images/issues/13046

References:

- https://github.com/actions/runner-images/issues/13046
